### PR TITLE
full names for config fields, removed logging to non-existent file

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,7 @@ dependencies:
 - containers
 - configurator        # for use Data.Configurator ( to work with config )
 - time                # Data.Time.Calendar Data.Time (to add current time at the log )
+- directory           # for System.Directory (check if logs file exist)
 
 # About ghc options read here. https://ghc.gitlab.haskell.org/ghc/doc/users_guide/using-warnings.html#
 ghc-options:

--- a/src/ConfigurationTypes.hs
+++ b/src/ConfigurationTypes.hs
@@ -1,4 +1,4 @@
--- | type for default config,  FrontEndType
+-- | type for default config and selection FrontEndType
 module ConfigurationTypes
   ( FrontEndType (..),
     ConfigDefault (..),
@@ -8,10 +8,16 @@ where
 data FrontEndType = ConsoleFrontEnd | TelegramFrontEnd {token :: String}
 
 data ConfigDefault = ConfigDefault
-  { helpReply :: String, -- helpMsg bot response for /help
-    repeatReply :: String, -- repQuestion bot response for /repeat
-    repetitionCount :: Int, -- default amount of times to echo a message
-    stdError :: String, -- loggin to Terminal or File
-    minLogLevel :: String, -- min loggin level. Must be Debug, Info, Warning, Error
-    frontEnd :: String -- type of bot Console, Telegram
+  { -- | helpReply - helpMsg bot response for /help
+    helpReply :: String,
+    -- | repeatReply - repQuestion bot response for /repeat
+    repeatReply :: String,
+    -- | repetitionCount - default amount of times to echo a message
+    repetitionCount :: Int,
+    -- | stdError - loggin to Terminal or File
+    stdError :: String,
+    -- | minLogLevel - minimum loggin level. Must be Debug, Info, Warning, Error
+    minLogLevel :: String,
+    -- | frontEnd - type of bot Console or Telegram
+    frontEnd :: String
   }

--- a/templateConfig.conf
+++ b/templateConfig.conf
@@ -5,9 +5,9 @@ config {
     helpReply = "It is a help message" # answer for /help comand
     repeatReply  = "How many?"         # answer for /repeat comand  
     repetitionCount = 3                # amount of repetition
-    stdError = "C"                     # logger to console or file -  C - Console  F- File
-    minLogLevel = "D"                  # minimum loger level - D - Debug I - Info W - Warning  E - Error
-    frontEnd = "T"                     # bot's type  - С - Console  T - Telegram
-    token = ""                         # you telegram token
+    stdError = "Terminal"              # loger records at: "Terminal" - terminal or "File"- file
+    minLogLevel = "Debug"              # minimum loger level: "Debug" - Debug, "Info" - Info, "Warning" - Warning,  "Error" - Error
+    frontEnd = "Console"               # bot's type: "Console" - console or "Telegram" - Telegram
+    token = ""                         # your telegram token
        }
 


### PR DESCRIPTION
1. Исправила названия полей в конфиге на полные.
2. При синтаксических ошибках в значениях полей, загружаю значения из конфига по умолчанию.
3. При отсутствии поля в файле конфига, загружаю значение отсутствующего поля из конфига по умолчанию. Исправлена ОШИБКА, так как раньше в конфиге по умолчанию отсутствовало значение поля ConfigurationTypes.frontEnd = "Console"
4.  Если файл logs отсутствует в папке проекта, то файл создается и в него пишется лог. Исправлена ОШИБКА, так как раньше при отсутствии файла logs, замечаний программа не выдавала и при этом логи просто  писались в никуда.
5. Осталась следующая ОШИБКА. Если у меня открыт  logs файл, и при этом я запускаю бота с логированием в терминал, то возникает исключение. То есть мне нужно сначала вручную закрыть logs файл, а потом запустить бота.  